### PR TITLE
Fix for issue #217: Refactor admin controllers code (Issues/GitHub 217)

### DIFF
--- a/app/code/community/Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/IndexController.php
+++ b/app/code/community/Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/IndexController.php
@@ -1,7 +1,11 @@
 <?php
+
 /**
- * Author: Sean Dunagan
- * Created: 9/14/15
+ *
+ * @category    Reverb
+ * @package     Reverb_ProcessQueue
+ * @author      Sean Dunagan
+ * @author      Timur Zaynullin <zztimur@gmail.com>
  */
 
 class Reverb_ProcessQueue_Adminhtml_ProcessQueue_IndexController

--- a/app/code/community/Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/IndexController.php
+++ b/app/code/community/Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/IndexController.php
@@ -53,8 +53,7 @@ class Reverb_ProcessQueue_Adminhtml_ProcessQueue_IndexController
         {
             $task_codes_string = implode(', ', $task_codes);
             $error_message = $this->__(self::ERROR_CLEARING_ALL_TASKS, $task_codes_string, $e->getMessage());
-            Mage::getSingleton('reverb_process_queue/log')->logQueueProcessorError($error_message);
-            $this->_getAdminHelper()->throwRedirectException($error_message, '*/*/index');
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         if (!empty($task_code))
@@ -81,8 +80,7 @@ class Reverb_ProcessQueue_Adminhtml_ProcessQueue_IndexController
         {
             $task_codes_string = implode(', ', $task_codes);
             $error_message = $this->__(self::ERROR_CLEARING_SUCCESSFUL_TASKS, $task_codes_string, $e->getMessage());
-            Mage::getSingleton('reverb_process_queue/log')->logQueueProcessorError($error_message);
-            $this->_getAdminHelper()->throwRedirectException($error_message, '*/*/index');
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         if (!empty($task_code))

--- a/app/code/community/Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/Unique/IndexController.php
+++ b/app/code/community/Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/Unique/IndexController.php
@@ -6,51 +6,51 @@
 
 require_once('Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/IndexController.php');
 class Reverb_ProcessQueue_Adminhtml_ProcessQueue_Unique_IndexController
-    extends Reverb_ProcessQueue_Adminhtml_ProcessQueue_IndexController
-    implements Reverb_Base_Controller_Adminhtml_Form_Interface
+  extends Reverb_ProcessQueue_Adminhtml_ProcessQueue_IndexController
+  implements Reverb_Base_Controller_Adminhtml_Form_Interface
 {
     protected function _getTaskProcessor()
     {
-        return Mage::helper('reverb_process_queue/task_processor_unique');
+      return Mage::helper('reverb_process_queue/task_processor_unique');
     }
 
     public function getControllerActiveMenuPath()
     {
-        return 'system/reverb_process_queue_unique';
+      return 'system/reverb_process_queue_unique';
     }
 
     public function getModuleInstanceDescription()
     {
-        return 'Unique Process Queue Tasks';
+      return 'Unique Process Queue Tasks';
     }
 
     public function getIndexBlockName()
     {
-        return 'adminhtml_task_unique_index';
+      return 'adminhtml_task_unique_index';
     }
 
     public function getObjectParamName()
     {
-        return 'unique_task';
+      return 'task_unique';
     }
 
     public function getObjectDescription()
     {
-        return 'Unique Task';
+      return 'Unique Task';
     }
 
     public function getModuleInstance()
     {
-        return 'task_unique';
+      return 'task_unique';
     }
 
     public function getFormBlockName()
     {
-        return 'adminhtml_task_unique';
+      return 'adminhtml_task_unique';
     }
 
     public function getIndexActionsController()
     {
-        return 'ProcessQueue_unique_index';
+      return 'ProcessQueue_unique_index';
     }
 }

--- a/app/code/community/Reverb/ReverbSync/Helper/Admin.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Admin.php
@@ -4,7 +4,7 @@ class Reverb_ReverbSync_Helper_Admin extends Mage_Core_Helper_Data
 {
     protected $_moduleName = 'ReverbSync';
 
-    public function throwRedirectException($error_message, $redirect_path, $redirect_arguments = array())
+    public function throwRedirectException($error_message, $redirect_path = '*/*/index', $redirect_arguments = array())
     {
         $this->addAdminErrorMessage($error_message);
         Mage::log($error_message, null, 'reverb_adminhtml_sync.log');

--- a/app/code/community/Reverb/ReverbSync/Model/Mapper/Product.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Mapper/Product.php
@@ -1,12 +1,16 @@
 <?php
 
 /**
- * Author: Sean Dunagan
- * Created: 8/17/15
  * Class Reverb_ReverbSync_Model_Mapper_Product
  *
  * This model meant to be referenced as a Singleton via Mage::getSingleton() functionality
+ *
+ * @category    Reverb
+ * @package     Reverb_ReverbSync
+ * @author      Sean Dunagan
+ * @author      Timur Zaynullin <zztimur@gmail.com>
  */
+
 class Reverb_ReverbSync_Model_Mapper_Product
 {
     const LISTING_CREATION_ENABLED_CONFIG_PATH = 'ReverbSync/reverbDefault/enable_image_sync';

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Category/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Category/SyncController.php
@@ -18,7 +18,7 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Category_SyncController extends Rev
         if (!$this->getRequest()->isPost())
         {
             $error_message = self::ERROR_SUBMISSION_NOT_POST;
-            $this->_setSessionErrorAndRedirect($error_message);
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         $post_array = $this->getRequest()->getPost();
@@ -41,22 +41,10 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Category_SyncController extends Rev
         catch(Exception $e)
         {
             $error_message = sprintf(self::EXCEPTION_CATEGORY_MAPPING, $e->getMessage());
-            $this->_setSessionErrorAndRedirect($error_message);
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         $this->_redirect('*/*/index');
-    }
-
-    /**
-     * @param $error_message
-     * @throws Reverb_ReverbSync_Controller_Varien_Exception
-     */
-    protected function _setSessionErrorAndRedirect($error_message)
-    {
-        Mage::getSingleton('adminhtml/session')->addError($this->__($error_message));
-        $exception = new Reverb_ReverbSync_Controller_Varien_Exception($error_message);
-        $exception->prepareRedirect('*/*/index');
-        throw $exception;
     }
 
     public function getUriPathForAction($action)

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Category/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Category/SyncController.php
@@ -1,7 +1,11 @@
 <?php
+
 /**
- * Author: Sean Dunagan
- * Created: 9/11/15
+ *
+ * @category    Reverb
+ * @package     Reverb_ReverbSync
+ * @author      Sean Dunagan
+ * @author      Timur Zaynullin <zztimur@gmail.com>
  */
 
 require_once('Reverb/ReverbSync/controllers/Adminhtml/BaseController.php');

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Category/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Category/SyncController.php
@@ -7,11 +7,6 @@
 require_once('Reverb/ReverbSync/controllers/Adminhtml/BaseController.php');
 class Reverb_ReverbSync_Adminhtml_ReverbSync_Category_SyncController extends Reverb_ReverbSync_Adminhtml_BaseController
 {
-    const BULK_SYNC_EXCEPTION = 'An uncaught exception occurred while executing the Reverb Bulk Product Sync via the admin panel: %s';
-    const SUCCESS_BULK_SYNC_COMPLETED = 'Reverb Bulk product sync process completed.';
-    const SUCCESS_BULK_SYNC_QUEUED_UP = '%s products have been queued to be synced with Reverb';
-    const EXCEPTION_STOP_BULK_SYNC = 'An exception occurred while attempting to stop all reverb listing sync tasks: %s';
-    const SUCCESS_STOPPED_LISTING_SYNCS = 'Stopped all pending Reverb Listing Sync tasks';
     const ERROR_SUBMISSION_NOT_POST = 'There was an error with your submission. Please try again.';
     const EXCEPTION_CATEGORY_MAPPING = 'An error occurred while attempting to set the Reverb-Magento category mapping: %s';
 

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/Image/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/Image/SyncController.php
@@ -27,31 +27,19 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_Image_SyncController
     }
 
     public function actOnTaskAction()
-    {
+    {   
         $task_id = $this->getRequest()->getParam($this->getObjectParamName());
         $uniqueQueueTask = Mage::getModel('reverb_process_queue/task_unique')->load($task_id);
-        if ((!is_object($uniqueQueueTask)) || (!$uniqueQueueTask->getId()))
-        {
+        if ((!is_object($uniqueQueueTask)) || (!$uniqueQueueTask->getId())) {
             $error_message = $this->__(self::CONST_INVALID_TASK_ID, $task_id);
-            $this->_logSyncError($error_message);
-            Mage::getSingleton('adminhtml/session')->addError($this->__($error_message));
-            $exception = new Reverb_ReverbSync_Controller_Varien_Exception($error_message);
-            $exception->prepareRedirect('*/*/index');
-            throw $exception;
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
-        try
-        {
+        try {
             Mage::helper('reverb_process_queue/task_processor_unique')->processQueueTask($uniqueQueueTask);
-        }
-        catch(Exception $e)
-        {
+        } catch(Exception $e) {
             $error_message = sprintf(self::EXCEPTION_ACT_ON_TASK, $task_id, $e->getMessage());
-            $this->_logSyncError($error_message);
-            Mage::getSingleton('adminhtml/session')->addError($this->__($error_message));
-            $exception = new Reverb_ReverbSync_Controller_Varien_Exception($error_message);
-            $exception->prepareRedirect('*/*/index');
-            throw $exception;
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         $action_text = $uniqueQueueTask->getActionText();
@@ -60,11 +48,6 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_Image_SyncController
         $notice_message = sprintf(self::NOTICE_TASK_ACTION, $action_text, $filename, $sku);
         Mage::getSingleton('adminhtml/session')->addNotice($this->__($notice_message));
         $this->_redirect('*/*/index');
-    }
-
-    protected function _logSyncError($error_message)
-    {
-        Mage::getSingleton('reverbSync/log')->logListingImageSyncError($error_message);
     }
 
     public function canAdminUpdateStatus()

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/Image/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/Image/SyncController.php
@@ -7,47 +7,14 @@ require_once('Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/Unique/Inde
 class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_Image_SyncController
     extends Reverb_ProcessQueue_Adminhtml_ProcessQueue_Unique_IndexController
 {
-    const CONST_INVALID_TASK_ID = 'An invalid Unique Task id was passed to the Reverb Listings Image Sync Controller: %s';
-    const EXCEPTION_ACT_ON_TASK = 'An error occurred while acting on the listings image sync with id %s: %s';
     const NOTICE_TASK_ACTION = 'The attempt to sync image file %s for product %s on Reverb has completed.';
 
     public function indexAction()
     {
-        $module_groupname = $this->getModuleGroupname();
-        $module_description = $this->getModuleInstanceDescription();
-
-        $this->loadLayout()
-            ->_setActiveMenuValue()
-            ->_setSetupTitle(Mage::helper($module_groupname)->__($module_description))
-            ->_addBreadcrumb()
-            ->_addBreadcrumb(Mage::helper($module_groupname)->__($module_description), Mage::helper($module_groupname)->__($module_description))
+        $this->_initAction()
             ->_addContent($this->getLayout()->createBlock('ReverbSync/adminhtml_listings_image_unique_index'))
             ->_addContent($this->getLayout()->createBlock('ReverbSync/adminhtml_listings_image_task_unique_index'))
             ->renderLayout();
-    }
-
-    public function actOnTaskAction()
-    {   
-        $task_id = $this->getRequest()->getParam($this->getObjectParamName());
-        $uniqueQueueTask = Mage::getModel('reverb_process_queue/task_unique')->load($task_id);
-        if ((!is_object($uniqueQueueTask)) || (!$uniqueQueueTask->getId())) {
-            $error_message = $this->__(self::CONST_INVALID_TASK_ID, $task_id);
-            $this->_getAdminHelper()->throwRedirectException($error_message);
-        }
-
-        try {
-            Mage::helper('reverb_process_queue/task_processor_unique')->processQueueTask($uniqueQueueTask);
-        } catch(Exception $e) {
-            $error_message = sprintf(self::EXCEPTION_ACT_ON_TASK, $task_id, $e->getMessage());
-            $this->_getAdminHelper()->throwRedirectException($error_message);
-        }
-
-        $action_text = $uniqueQueueTask->getActionText();
-        $filename = $uniqueQueueTask->getSubjectId();
-        $sku = Mage::helper('ReverbSync/sync_image')->getSkuForTask($uniqueQueueTask);
-        $notice_message = sprintf(self::NOTICE_TASK_ACTION, $action_text, $filename, $sku);
-        Mage::getSingleton('adminhtml/session')->addNotice($this->__($notice_message));
-        $this->_redirect('*/*/index');
     }
 
     public function canAdminUpdateStatus()
@@ -75,19 +42,14 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_Image_SyncController
         return 'reverb/reverb_listings_image_sync';
     }
 
+    public function getObjectParamName()
+    {
+      return 'task_id';
+    }
+
     public function getModuleInstanceDescription()
     {
         return 'Reverb Listings Image Sync Tasks';
-    }
-
-    public function getObjectParamName()
-    {
-        return 'task_id';
-    }
-
-    public function getObjectDescription()
-    {
-        return 'Sync Task';
     }
 
     public function getIndexActionsController()

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/Image/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/Image/SyncController.php
@@ -1,6 +1,11 @@
 <?php
+
 /**
- * Author: Sean Dunagan
+ *
+ * @category    Reverb
+ * @package     Reverb_ReverbSync
+ * @author      Sean Dunagan
+ * @author      Timur Zaynullin <zztimur@gmail.com>
  */
 
 require_once('Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/Unique/IndexController.php');

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/SyncController.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ *
+ * @category    Reverb
+ * @package     Reverb_ReverbSync
+ * @author      Sean Dunagan
+ * @author      Timur Zaynullin <zztimur@gmail.com>
+ */
+
 require_once('Reverb/ReverbSync/controllers/Adminhtml/BaseController.php');
 class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_SyncController extends Reverb_ReverbSync_Adminhtml_BaseController
 {

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/SyncController.php
@@ -6,7 +6,6 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_SyncController extends Rev
     const BULK_SYNC_EXCEPTION = 'Error executing the Reverb Bulk Product Sync via the admin panel: %s';
     const EXCEPTION_CLEARING_ALL_LISTING_TASKS = 'An error occurred while clearing all listing tasks from the system: %s';
     const ERROR_CLEARING_SUCCESSFUL_SYNC = 'An error occurred while clearing successful listing syncs: %s';
-    const SUCCESS_BULK_SYNC_COMPLETED = 'Reverb Bulk product sync process completed.';
     const SUCCESS_BULK_SYNC_QUEUED_UP = '%s products have been queued for sync. Please wait a few minutes and refresh this page...';
     const EXCEPTION_STOP_BULK_SYNC = 'Error attempting to stop all reverb listing sync tasks: %s';
     const SUCCESS_STOPPED_LISTING_SYNCS = 'Stopped all pending Reverb Listing Sync tasks';
@@ -33,12 +32,12 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_SyncController extends Rev
         {
             // We don't know what caused this exception. Log it and throw redirect exception
             $error_message = $this->__(self::BULK_SYNC_EXCEPTION, $e->getMessage());
-            $this->_getAdminHelper()->throwRedirectException($error_message, 'adminhtml/reports_reverbreport/index');
+            $this->_getAdminHelper()->throwRedirectException($error_message, $this->_getRedirectPath());
         }
 
         $success_message = $this->__(self::SUCCESS_BULK_SYNC_QUEUED_UP, $number_of_syncs_queued_up);
         $this->_getAdminHelper()->addAdminSuccessMessage($success_message);
-        $this->_redirect('adminhtml/reports_reverbreport/index');
+        $this->_redirect($this->_getRedirectPath());
     }
 
     public function stopBulkSyncAction()
@@ -58,12 +57,12 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_SyncController extends Rev
         {
             // We don't know what caused this exception. Log it and throw redirect exception
             $error_message = $this->__(self::EXCEPTION_STOP_BULK_SYNC, $e->getMessage());
-            $this->_getAdminHelper()->throwRedirectException($error_message, 'adminhtml/reports_reverbreport/index');
+            $this->_getAdminHelper()->throwRedirectException($error_message, $this->_getRedirectPath());
         }
 
         $success_message = $this->__(self::SUCCESS_STOPPED_LISTING_SYNCS);
         $this->_getAdminHelper()->addAdminSuccessMessage($success_message);
-        $this->_redirect('adminhtml/reports_reverbreport/index');
+        $this->_redirect($this->_getRedirectPath());
     }
 
     public function clearAllTasksAction()
@@ -76,12 +75,12 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_SyncController extends Rev
         catch(Exception $e)
         {
             $error_message = $this->__(self::EXCEPTION_CLEARING_ALL_LISTING_TASKS, $e->getMessage());
-            $this->_getAdminHelper()->throwRedirectException($error_message, 'adminhtml/reports_reverbreport/index');
+            $this->_getAdminHelper()->throwRedirectException($error_message, $this->_getRedirectPath());
         }
 
         $success_message = $this->__(self::SUCCESS_CLEAR_LISTING_SYNCS);
         $this->_getAdminHelper()->addAdminSuccessMessage($success_message);
-        $this->_redirect('adminhtml/reports_reverbreport/index');
+        $this->_redirect($this->_getRedirectPath());
     }
 
     public function clearSuccessfulTasksAction()
@@ -95,12 +94,12 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_SyncController extends Rev
         catch(Exception $e)
         {
             $error_message = $this->__(self::ERROR_CLEARING_SUCCESSFUL_SYNC, $e->getMessage());
-            $this->_getAdminHelper()->throwRedirectException($error_message, 'adminhtml/reports_reverbreport/index');
+            $this->_getAdminHelper()->throwRedirectException($error_message, $this->_getRedirectPath());
         }
 
         $success_message = $this->__(self::SUCCESS_CLEAR_SUCCESSFUL_LISTING_SYNCS);
         $this->_getAdminHelper()->addAdminSuccessMessage($success_message);
-        $this->_redirect('adminhtml/reports_reverbreport/index');
+        $this->_redirect($this->_getRedirectPath());
     }
 
     public function getBlockToShow()
@@ -127,5 +126,9 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_SyncController extends Rev
     public function getControllerActiveMenuPath()
     {
         return 'catalog/reverb_sync';
+    }
+
+    protected function _getRedirectPath() {
+        return 'adminhtml/reports_reverbreport/index';
     }
 }

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/Sync/UniqueController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/Sync/UniqueController.php
@@ -8,68 +8,22 @@ require_once('Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/Unique/Inde
 class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_Sync_UniqueController
     extends Reverb_ProcessQueue_Adminhtml_ProcessQueue_Unique_IndexController
 {
-    const EXCEPTION_LOAD_UNIQUE_TASK = 'An exception occurred while attempting to load a unique order task to manually act on the task: %s';
-    const EXCEPTION_ACT_ON_TASK = 'An error occurred while acting on the task for the order with Reverb Order Id %s: %s';
-    const GENERIC_ADMIN_FACING_ERROR_MESSAGE = 'An error occurred with your request. Please try again.';
     const EXCEPTION_SYNC_SHIPMENT_TRACKING = 'An error occurred while attempting to sync shipment tracking data with Reverb: %s';
-    const NOTICE_TASK_ACTION = 'The attempt to %s the Sync of Reverb Order with id %s has completed.';
     const NOTICE_SYNC_SHIPMENT_TRACKING = 'The attempt to sync shipment tracking data with Reverb has completed';
 
     public function indexAction()
     {
-        $module_groupname = $this->getModuleGroupname();
-        $module_description = $this->getModuleInstanceDescription();
-
-        $this->loadLayout()
-            ->_setActiveMenuValue()
-            ->_setSetupTitle(Mage::helper($module_groupname)->__($module_description))
-            ->_addBreadcrumb()
-            ->_addBreadcrumb(Mage::helper($module_groupname)->__($module_description), Mage::helper($module_groupname)->__($module_description))
+        $this->_initAction()
             ->_addContent($this->getLayout()->createBlock('ReverbSync/adminhtml_orders_unique_index'))
             ->_addContent($this->getLayout()->createBlock('ReverbSync/adminhtml_orders_task_unique_index'))
             ->renderLayout();
-    }
-
-    public function actOnTaskAction()
-    {
-        try
-        {
-            $task_id = $this->getRequest()->getParam('task_id');
-            $uniqueQueueTask = Mage::getModel('reverb_process_queue/task_unique')->load($task_id);
-            if ((!is_object($uniqueQueueTask)) || (!$uniqueQueueTask->getId()))
-            {
-                throw new Exception('An invalid Unique Task Id was passed to the Reverb Orders Sync Unique Controller: ' . $reverb_order_id);
-            }
-        }
-        catch(Exception $e)
-        {
-            $error_message = sprintf(self::EXCEPTION_LOAD_UNIQUE_TASK, $e->getMessage());
-            $this->_getAdminHelper()->throwRedirectException($error_message);
-        }
-
-        try
-        {
-            Mage::helper('reverb_process_queue/task_processor_unique')->processQueueTask($uniqueQueueTask);
-        }
-        catch(Exception $e)
-        {
-            $error_message = sprintf(self::EXCEPTION_ACT_ON_TASK, $task_id, $e->getMessage());
-            $this->_getAdminHelper()->throwRedirectException($error_message);
-        }
-
-        $action_text = $uniqueQueueTask->getActionText();
-        $reverb_order_id = $uniqueQueueTask->getUniqueId();
-        $notice_message = sprintf(self::NOTICE_TASK_ACTION, $action_text, $reverb_order_id);
-        Mage::getSingleton('adminhtml/session')->addNotice($this->__($notice_message));
-        $this->_redirect('*/*/index');
     }
 
     public function syncShipmentTrackingAction()
     {
         try
         {
-            Mage::helper('reverb_process_queue/task_processor_unique')
-                ->processQueueTasks(Reverb_ReverbSync_Model_Sync_Shipment_Tracking::JOB_CODE);
+            $this->_getTaskProcessor()->processQueueTasks(Reverb_ReverbSync_Model_Sync_Shipment_Tracking::JOB_CODE);
         }
         catch(Exception $e)
         {
@@ -111,11 +65,6 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_Sync_UniqueController
         return 'Reverb Order Creation and Shipment Tracking Sync Tasks';
     }
 
-    public function getObjectParamName()
-    {
-        return 'unique_task';
-    }
-
     public function getObjectDescription()
     {
         return 'Sync Task';
@@ -129,5 +78,10 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_Sync_UniqueController
     protected function _getModuleBlockGroupname()
     {
         return 'ReverbSync';
+    }
+
+    public function getObjectParamName()
+    {
+      return 'task_id';
     }
 }

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/Sync/UniqueController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/Sync/UniqueController.php
@@ -1,7 +1,11 @@
 <?php
+
 /**
- * Author: Sean Dunagan
- * Created: 9/16/15
+ *
+ * @category    Reverb
+ * @package     Reverb_ReverbSync
+ * @author      Sean Dunagan
+ * @author      Timur Zaynullin <zztimur@gmail.com>
  */
 
 require_once('Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/Unique/IndexController.php');

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/Sync/UniqueController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/Sync/UniqueController.php
@@ -44,11 +44,7 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_Sync_UniqueController
         catch(Exception $e)
         {
             $error_message = sprintf(self::EXCEPTION_LOAD_UNIQUE_TASK, $e->getMessage());
-            $this->_logOrderSyncError($error_message);
-            Mage::getSingleton('adminhtml/session')->addError($this->__(self::GENERIC_ADMIN_FACING_ERROR_MESSAGE));
-            $exception = new Reverb_ReverbSync_Controller_Varien_Exception($error_message);
-            $exception->prepareRedirect('*/*/index');
-            throw $exception;
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         try
@@ -58,11 +54,7 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_Sync_UniqueController
         catch(Exception $e)
         {
             $error_message = sprintf(self::EXCEPTION_ACT_ON_TASK, $task_id, $e->getMessage());
-            $this->_logOrderSyncError($error_message);
-            Mage::getSingleton('adminhtml/session')->addError($this->__($error_message));
-            $exception = new Reverb_ReverbSync_Controller_Varien_Exception($error_message);
-            $exception->prepareRedirect('*/*/index');
-            throw $exception;
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         $action_text = $uniqueQueueTask->getActionText();
@@ -82,21 +74,11 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_Sync_UniqueController
         catch(Exception $e)
         {
             $error_message = sprintf(self::EXCEPTION_SYNC_SHIPMENT_TRACKING, $e->getMessage());
-            Mage::getSingleton('adminhtml/session')->addError($this->__($error_message));
-            Mage::getSingleton('reverbSync/log')->logShipmentTrackingSyncError($error_message);
-
-            $exception = new Reverb_ReverbSync_Model_Exception_Redirect($error_message);
-            $exception->prepareRedirect('*/*/index');
-            throw $exception;
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         Mage::getSingleton('adminhtml/session')->addNotice($this->__(self::NOTICE_SYNC_SHIPMENT_TRACKING));
         $this->_redirect('*/*/index');
-    }
-
-    protected function _logOrderSyncError($error_message)
-    {
-        Mage::getSingleton('reverbSync/log')->logOrderSyncError($error_message);
     }
 
     public function canAdminUpdateStatus()

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/SyncController.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ *
+ * @category    Reverb
+ * @package     Reverb_ReverbSync
+ * @author      Sean Dunagan
+ * @author      Timur Zaynullin <zztimur@gmail.com>
+ */
+
 require_once('Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/IndexController.php');
 class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_SyncController
     extends Reverb_ProcessQueue_Adminhtml_ProcessQueue_IndexController

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/SyncController.php
@@ -36,10 +36,12 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_SyncController
             $task_param_name = $this->getObjectParamName();
             $task_id = $this->getRequest()->getParam($task_param_name);
             $error_message = sprintf(self::ERROR_DENIED_ORDER_CREATION_STATUS_UPDATE);
-            Mage::getSingleton('adminhtml/session')->addError($this->__($error_message));
-            $exception = new Reverb_ReverbSync_Controller_Varien_Exception();
-            $exception->prepareRedirect('adminhtml/ReverbSync_orders_sync/edit', array($task_param_name => $task_id));
-            throw $exception;
+
+            // TODO:
+            $this->_getAdminHelper()->throwRedirectException($error_message,
+                                                             'adminhtml/ReverbSync_orders_sync/edit',
+                                                             array($task_param_name => $task_id)
+                                                             );
         }
 
         parent::saveAction();
@@ -60,12 +62,7 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_SyncController
         catch(Exception $e)
         {
             $error_message = $this->__(self::EXCEPTION_BULK_ORDERS_SYNC, $e->getMessage());
-            Mage::getSingleton('reverbSync/log')->logOrderSyncError($error_message);
-            Mage::getSingleton('adminhtml/session')->addError($this->__($error_message));
-
-            $redirectException = new Reverb_ReverbSync_Model_Exception_Redirect($error_message);
-            $redirectException->prepareRedirect('*/*/index');
-            throw $redirectException;
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         Mage::getSingleton('adminhtml/session')->addNotice($this->__(self::NOTICE_QUEUED_ORDERS_FOR_SYNC));
@@ -85,12 +82,7 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_SyncController
         catch(Exception $e)
         {
             $error_message = $this->__(self::EXCEPTION_PROCESSING_DOWNLOADED_TASKS, $e->getMessage());
-            Mage::getSingleton('reverbSync/log')->logOrderSyncError($error_message);
-            Mage::getSingleton('adminhtml/session')->addError($this->__($error_message));
-
-            $redirectException = new Reverb_ReverbSync_Model_Exception_Redirect($error_message);
-            $redirectException->prepareRedirect('*/*/index');
-            throw $redirectException;
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         Mage::getSingleton('adminhtml/session')->addNotice($this->__(self::NOTICE_PROCESSING_DOWNLOADED_TASKS));
@@ -115,10 +107,7 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_SyncController
         {
             $error_message = sprintf(self::EXCEPTION_LOAD_TASK, $e->getMessage());
             $this->_logOrderSyncError($error_message);
-            Mage::getSingleton('adminhtml/session')->addError($this->__(self::GENERIC_ADMIN_FACING_ERROR_MESSAGE));
-            $exception = new Reverb_ReverbSync_Controller_Varien_Exception($error_message);
-            $exception->prepareRedirect('*/*/index');
-            throw $exception;
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         try
@@ -128,22 +117,16 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_SyncController
         catch(Exception $e)
         {
             $error_message = sprintf(self::EXCEPTION_ACT_ON_TASK, $reverb_order_id, $e->getMessage());
+
+            // TODO now it uses protected function as a shortcut
             $this->_logOrderSyncError($error_message);
-            Mage::getSingleton('adminhtml/session')->addError($this->__($error_message));
-            $exception = new Reverb_ReverbSync_Controller_Varien_Exception($error_message);
-            $exception->prepareRedirect('*/*/index');
-            throw $exception;
+            $this->_getAdminHelper()->throwRedirectException($error_message);
         }
 
         $action_text = $queueTask->getActionText();
         $notice_message = sprintf(self::NOTICE_TASK_ACTION, $action_text, $reverb_order_id);
         Mage::getSingleton('adminhtml/session')->addNotice($this->__($notice_message));
         $this->_redirect('*/*/index');
-    }
-
-    protected function _logOrderSyncError($error_message)
-    {
-        Mage::getSingleton('reverbSync/log')->logOrderSyncError($error_message);
     }
 
     public function canAdminUpdateStatus()

--- a/app/code/community/Reverb/ReverbSync/etc/adminhtml.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/adminhtml.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0"?>
-
+<!--
+/**
+ *
+ * @category    Reverb
+ * @package     Reverb_ReverbSync
+ * @author      Sean Dunagan
+ * @author      Timur Zaynullin <zztimur@gmail.com>
+ */
+-->
 <config>
     <acl>
         <resources>

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0"?>
+<!--
+/**
+ *
+ * @category    Reverb
+ * @package     Reverb_ReverbSync
+ * @author      Sean Dunagan
+ */
+-->
 <config>
   <modules>
     <Reverb_ReverbSync>

--- a/app/code/community/Reverb/ReverbSync/etc/system.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/system.xml
@@ -1,3 +1,13 @@
+<?xml version="1.0"?>
+<!--
+/**
+ *
+ * @category    Reverb
+ * @package     Reverb_ReverbSync
+ * @author      Sean Dunagan
+ * @author      Timur Zaynullin <zztimur@gmail.com>
+ */
+-->
 <config>
   <tabs>
     <ReverbSync translate="label" module="ReverbSync">

--- a/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.12-0.1.13.php
+++ b/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.12-0.1.13.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ *
+ * @category    Reverb
+ * @package     Reverb_ReverbSync
+ * @author      Timur Zaynullin <zztimur@gmail.com>
+ */
+
 $installer = $this;
 /* @var $installer Mage_Core_Model_Resource_Setup */
 

--- a/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.13-0.1.14.php
+++ b/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.13-0.1.14.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ *
+ * @category    Reverb
+ * @package     Reverb_ReverbSync
+ * @author      Timur Zaynullin <zztimur@gmail.com>
+ */
+
 $installer = $this;
 /* @var $installer Mage_Core_Model_Resource_Setup */
 


### PR DESCRIPTION
It was really hard to work with all the duplicate code and bugs, where action buttons wouldn't work.
So I took some time to slightly adjust the code for admin controllers.

Quick overview:
- There was bunch of redundant logging involved, I removed the duplicates and combined logging for redirect errors in one function.
- IndexAction for controllers extended from ProcessQueue were repetitive. They were pulled up to Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/IndexController.php in the _initAction as preparation.
- Same goes for actOnTaskAction. With all those properties per each controller, there's really no need to have that function per each child class.
- return URL parameter on action buttons was implemented so inconsistently and randomly, that I removed it, as there is no case were it's needed.
- pulled some constants to ProcessQueue level. Removed unused ones.
